### PR TITLE
Disable WebView file access in HandlerActivity

### DIFF
--- a/app/src/main/java/nl/privacydragon/bookwyrm/HandlerActivity.java
+++ b/app/src/main/java/nl/privacydragon/bookwyrm/HandlerActivity.java
@@ -64,7 +64,11 @@ public class HandlerActivity extends AppCompatActivity {
         myWebView.setVisibility(View.GONE);
         myWebView.getSettings().setJavaScriptEnabled(true);
         myWebView.getSettings().setDomStorageEnabled(true);
-        myWebView.getSettings().setAllowFileAccess(true);
+        // The WebView only ever loads the user's configured bookwyrm
+        // server URL (toGoServer), so file:// access is not needed.
+        // Bundled assets under file:///android_asset/ are still
+        // reachable regardless of this flag.
+        myWebView.getSettings().setAllowFileAccess(false);
         myWebView.getSettings().setAllowContentAccess(true);
         myWebView.addJavascriptInterface(new Object()
         {


### PR DESCRIPTION
Closes #21.

`HandlerActivity` enables `setAllowFileAccess(true)` on the main bookwyrm WebView while also attaching the `scan` JS bridge:

```java
myWebView.getSettings().setJavaScriptEnabled(true);
myWebView.getSettings().setDomStorageEnabled(true);
myWebView.getSettings().setAllowFileAccess(true);
myWebView.getSettings().setAllowContentAccess(true);
myWebView.addJavascriptInterface(new Object() {
    @JavascriptInterface
    public void performClick(String what) { ... ScanBarCode(); }
}, "scan");
```

The WebView only ever loads `toGoServer`, the https URL of the user's configured bookwyrm instance, so it never needs to load a `file://` URL. With the `scan` bridge attached, the flag widens what a stray file-URL load could reach.

### Change

Flip `setAllowFileAccess(true)` to `setAllowFileAccess(false)`. `file:///android_asset/*` loads remain permitted on every supported Android version, so this does not break any asset access.

`StartActivity` does not call `setAllowFileAccess` and is unaffected.