### PR TITLE
Catch ActivityNotFoundException around external link startActivity

### DIFF
--- a/app/src/main/java/nl/privacydragon/bookwyrm/HandlerActivity.java
+++ b/app/src/main/java/nl/privacydragon/bookwyrm/HandlerActivity.java
@@ -241,7 +241,11 @@ public class HandlerActivity extends AppCompatActivity {
             }
             // Otherwise, it should go to the default browser instead.
             Intent intent = new Intent(Intent.ACTION_VIEW, request.getUrl());
-            startActivity(intent);
+            try {
+                startActivity(intent);
+            } catch (ActivityNotFoundException e) {
+                android.util.Log.w("HandlerActivity", "No app installed to handle " + request.getUrl(), e);
+            }
             return true;
         }
 

--- a/app/src/main/java/nl/privacydragon/bookwyrm/StartActivity.java
+++ b/app/src/main/java/nl/privacydragon/bookwyrm/StartActivity.java
@@ -433,7 +433,11 @@ public class StartActivity extends AppCompatActivity {
             }
             // Otherwise, it should go to the default browser instead.
             Intent intent = new Intent(Intent.ACTION_VIEW, request.getUrl());
-            startActivity(intent);
+            try {
+                startActivity(intent);
+            } catch (ActivityNotFoundException e) {
+                android.util.Log.w("StartActivity", "No app installed to handle " + request.getUrl(), e);
+            }
             return true;
         }
 


### PR DESCRIPTION
Closes #24.

`HandlerActivity` and `StartActivity` both hand off-server URLs to the system via `startActivity(Intent.ACTION_VIEW, ...)` inside `shouldOverrideUrlLoading`. If no installed app can handle the intent (no default browser, browser disabled, work profile, stripped ROM, etc.) `startActivity` raises `ActivityNotFoundException` and the activity crashes. Bookwyrm links out to all sorts of hosts, so any of them can trip this on the wrong device.

This wraps the call in a try / catch for `ActivityNotFoundException` and logs a warning. The click becomes a silent no-op, matching the standard outcome for a missing handler. `android.content.ActivityNotFoundException` is already imported in both files.

```diff
             // Otherwise, it should go to the default browser instead.
             Intent intent = new Intent(Intent.ACTION_VIEW, request.getUrl());
-            startActivity(intent);
+            try {
+                startActivity(intent);
+            } catch (ActivityNotFoundException e) {
+                android.util.Log.w("HandlerActivity", "No app installed to handle " + request.getUrl(), e);
+            }
             return true;
```

Same change applied to `StartActivity.java`. Nothing else moves.